### PR TITLE
Fix duplicated statement

### DIFF
--- a/.i3/config
+++ b/.i3/config
@@ -156,5 +156,4 @@ bar {
 }
 
 # Removing border from applications
-for_window [class="^.*"] border pixel 1
-new_window 1pixel
+new_window pixel 1


### PR DESCRIPTION
No need to use `for_window` rule, `new_window` applies to everything, plus `1pixel` is deprecated.
